### PR TITLE
fix: update cmdline.Set() to drop the value being overwritten

### DIFF
--- a/procfs/cmdline.go
+++ b/procfs/cmdline.go
@@ -195,7 +195,7 @@ func (c *Cmdline) Set(k string, v *Parameter) {
 
 	for i, value := range c.Parameters {
 		if value.key == k {
-			c.Parameters = append(c.Parameters[:i], append([]*Parameter{v}, c.Parameters[i:]...)...)
+			c.Parameters = append(c.Parameters[:i], append([]*Parameter{v}, c.Parameters[i+1:]...)...)
 
 			return
 		}

--- a/procfs/cmdline_test.go
+++ b/procfs/cmdline_test.go
@@ -73,33 +73,38 @@ func (suite *KernelSuite) TestCmdlineGet() {
 
 func (suite *KernelSuite) TestCmdlineSet() {
 	for _, t := range []struct {
-		params   string
-		k        string
-		v        *Parameter
-		expected *Parameter
+		params         string
+		k              string
+		v              *Parameter
+		expected       *Parameter
+		expectedParams string
 	}{
 		{
 			"root=/dev/sda root=/dev/sdb",
 			"root",
 			&Parameter{key: "root", values: []string{"/dev/sdc"}},
 			&Parameter{key: "root", values: []string{"/dev/sdc"}},
+			"root=/dev/sdc",
 		},
 		{
 			"boot=xyz root=/dev/abc nogui console=tty0 console=ttyS0,9600",
 			"console",
-			&Parameter{key: "console", values: nil},
-			&Parameter{key: "console", values: nil},
+			&Parameter{key: "console", values: []string{""}},
+			&Parameter{key: "console", values: []string{""}},
+			"boot=xyz root=/dev/abc nogui console",
 		},
 		{
 			"initrd=initramfs.xz",
 			"initrd",
 			&Parameter{key: "initrd", values: []string{"/ROOT-A/initramfs.xz"}},
 			&Parameter{key: "initrd", values: []string{"/ROOT-A/initramfs.xz"}},
+			"initrd=/ROOT-A/initramfs.xz",
 		},
 	} {
 		cmdline := NewCmdline(t.params)
 		cmdline.Set(t.k, t.v)
 		suite.Assert().Equal(t.expected, cmdline.Get(t.k))
+		suite.Assert().Equal(t.expectedParams, cmdline.String())
 	}
 }
 


### PR DESCRIPTION
Before the fix, .Set() was keeping both old and new key values which
leads to unexpected state in cmdline and keeps overwritten values.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>